### PR TITLE
fix(chart): make the inspektor-gadget chart render and pass build-chart

### DIFF
--- a/helm/inspektor-gadget/.kube-linter.yaml
+++ b/helm/inspektor-gadget/.kube-linter.yaml
@@ -1,0 +1,17 @@
+# kube-linter config read by app-build-suite's KubeLinter step (build-chart).
+checks:
+  exclude:
+    # Inspektor Gadget is an eBPF node agent: the gadget DaemonSet needs
+    # SYS_ADMIN/NET_RAW/SYS_PTRACE, runs as root and mounts host /etc, /usr,
+    # /proc, /run, /var and /sys to attach tracers to the node. See the
+    # capability rationale in templates/daemonset.yaml (vendored upstream).
+    - drop-net-raw-capability
+    - privilege-escalation-container
+    - run-as-non-root
+    - sensitive-host-mounts
+    # The vendored upstream templates set no resource requests/limits and
+    # use the deprecated `serviceAccount` pod field; both are upstream's to
+    # change (templates are synced from inspektor-gadget/inspektor-gadget).
+    - unset-cpu-requirements
+    - unset-memory-requirements
+    - deprecated-service-account-field

--- a/helm/inspektor-gadget/Chart.yaml
+++ b/helm/inspektor-gadget/Chart.yaml
@@ -9,9 +9,10 @@ description: Please add description
 
 home: https://github.com/giantswarm/inspektor-gadget-app
 
-# If you have an icon/logo, you should add it to https://github.com/giantswarm/web-assets
-# and set the final URL as a value here and uncomment.
-#icon: https://s.giantswarm.io/app-icons/example/1/light.svg
+# Upstream Inspektor Gadget brand logo, served from
+# https://github.com/giantswarm/web-assets (assets/app-icons/inspektor-gadget/1).
+# app-build-suite fails build-chart without one.
+icon: https://s.giantswarm.io/app-icons/inspektor-gadget/1/light.svg
 
 sources:
 - https://github.com/some-org/some-repo

--- a/helm/inspektor-gadget/README.md
+++ b/helm/inspektor-gadget/README.md
@@ -12,6 +12,29 @@ Please add description
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| image.name | string | `"giantswarm/inspektor-gadget"` |  |
-| image.tag | string | `""` |  |
-| registry.domain | string | `"gsoci.azurecr.io"` |  |
+| config.hookMode | string | `"auto"` | How to get containers start/stop notifications (auto, crio, podinformer, nri, fanotify+ebpf) |
+| config.fallbackPodInformer | bool | `true` | Whether to use the fallback pod informer |
+| config.containerdSocketPath | string | `"/run/containerd/containerd.sock"` | Containerd CRI Unix socket path |
+| config.crioSocketPath | string | `"/run/crio/crio.sock"` | CRI-O CRI Unix socket path |
+| config.dockerSocketPath | string | `"/run/docker.sock"` | Docker Engine API Unix socket path |
+| config.podmanSocketPath | string | `"/run/podman/podman.sock"` | Podman API Unix socket path |
+| config.experimental | bool | `false` | Enable experimental features |
+| config.eventsBufferLength | string | `"16384"` | Events buffer length. A low value could impact horizontal scaling. |
+| config.daemonLogLevel | string | `"info"` | Daemon log level. Valid values are: "trace", "debug", "info", "warning", "error", "fatal", "panic" |
+| config.verifyGadgets | bool | `true` | Verify image-based gadgets |
+| config.gadgetsPublicKeys | list | `["-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh\nIr4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==\n-----END PUBLIC KEY-----\n"]` | Public keys used to verify image-based gadgets |
+| config.allowedGadgets | list | `[]` | List of allowed gadgets |
+| config.disallowGadgetsPulling | bool | `false` | Disallow pulling gadgets |
+| config.mountPullSecret | bool | `false` | Mount pull secret (gadget-pull-secret) to pull image-based gadgets from a private registry |
+| config.appArmorProfile | string | `"unconfined"` | AppArmor profile for the gadget container |
+| config.otelMetricsListen | bool | `false` | Enable the OpenTelemetry metrics listener |
+| config.otelMetricsAddress | string | `"0.0.0.0:2224"` | Address to listen on for OpenTelemetry metrics |
+| image.repository | string | `"ghcr.io/inspektor-gadget/inspektor-gadget"` | Container image repository. Upstream's image; there is no gsoci mirror yet. |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the container image |
+| image.tag | string | `""` | Tag for the container image; empty means the chart's appVersion |
+| nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the gadget DaemonSet |
+| affinity | object | `{}` | Affinity for the gadget DaemonSet |
+| capabilities | object | `{}` | Capabilities for the gadget container; empty means the upstream default set |
+| tolerations | list | `[]` | Extra tolerations for the gadget DaemonSet |
+| skipLabels | bool | `false` | Skip the Helm labels (upstream default is true; Giant Swarm charts carry the team label) |
+| additionalLabels | object | `{"enabled":false,"labels":{}}` | Labels added to all resources when `enabled` is true |

--- a/helm/inspektor-gadget/templates/_helpers.tpl
+++ b/helm/inspektor-gadget/templates/_helpers.tpl
@@ -34,9 +34,10 @@ app.kubernetes.io/component: controller
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 {{- if .Values.additionalLabels.enabled }}
-{{- if .Values.additionalLabels }}
-{{ toYaml .Values.additionalLabels }}
+{{- with .Values.additionalLabels.labels }}
+{{ toYaml . }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/inspektor-gadget/values.schema.json
+++ b/helm/inspektor-gadget/values.schema.json
@@ -3,12 +3,36 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+        "additionalLabels": {
+            "type": "object",
+            "description": "Labels added to all resources when `enabled` is true",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": false
+                }
+            }
+        },
+        "affinity": {
+            "type": "object",
+            "description": "Affinity for the gadget DaemonSet",
+            "additionalProperties": false
+        },
         "baseDomain": {
             "type": "string"
         },
         "bootstrapMode": {
             "type": "object",
             "additionalProperties": true
+        },
+        "capabilities": {
+            "type": "object",
+            "description": "Capabilities for the gadget container; empty means the upstream default set",
+            "additionalProperties": false
         },
         "chartOperator": {
             "type": "object",
@@ -34,6 +58,83 @@
         "clusterID": {
             "type": "string"
         },
+        "config": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "allowedGadgets": {
+                    "type": "array",
+                    "description": "List of allowed gadgets"
+                },
+                "appArmorProfile": {
+                    "type": "string",
+                    "description": "AppArmor profile for the gadget container"
+                },
+                "containerdSocketPath": {
+                    "type": "string",
+                    "description": "Containerd CRI Unix socket path"
+                },
+                "crioSocketPath": {
+                    "type": "string",
+                    "description": "CRI-O CRI Unix socket path"
+                },
+                "daemonLogLevel": {
+                    "type": "string",
+                    "description": "Daemon log level. Valid values are: \"trace\", \"debug\", \"info\", \"warning\", \"error\", \"fatal\", \"panic\""
+                },
+                "disallowGadgetsPulling": {
+                    "type": "boolean",
+                    "description": "Disallow pulling gadgets"
+                },
+                "dockerSocketPath": {
+                    "type": "string",
+                    "description": "Docker Engine API Unix socket path"
+                },
+                "eventsBufferLength": {
+                    "type": "string",
+                    "description": "Events buffer length. A low value could impact horizontal scaling."
+                },
+                "experimental": {
+                    "type": "boolean",
+                    "description": "Enable experimental features"
+                },
+                "fallbackPodInformer": {
+                    "type": "boolean",
+                    "description": "Whether to use the fallback pod informer"
+                },
+                "gadgetsPublicKeys": {
+                    "type": "array",
+                    "description": "Public keys used to verify image-based gadgets",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hookMode": {
+                    "type": "string",
+                    "description": "How to get containers start/stop notifications (auto, crio, podinformer, nri, fanotify+ebpf)"
+                },
+                "mountPullSecret": {
+                    "type": "boolean",
+                    "description": "Mount pull secret (gadget-pull-secret) to pull image-based gadgets from a private registry"
+                },
+                "otelMetricsAddress": {
+                    "type": "string",
+                    "description": "Address to listen on for OpenTelemetry metrics"
+                },
+                "otelMetricsListen": {
+                    "type": "boolean",
+                    "description": "Enable the OpenTelemetry metrics listener"
+                },
+                "podmanSocketPath": {
+                    "type": "string",
+                    "description": "Podman API Unix socket path"
+                },
+                "verifyGadgets": {
+                    "type": "boolean",
+                    "description": "Verify image-based gadgets"
+                }
+            }
+        },
         "gcpProject": {
             "type": "string"
         },
@@ -49,10 +150,26 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "name": {
-                    "type": "string"
+                "pullPolicy": {
+                    "type": "string",
+                    "description": "Pull policy for the container image"
+                },
+                "repository": {
+                    "type": "string",
+                    "description": "Container image repository. Upstream's image; there is no gsoci mirror yet."
                 },
                 "tag": {
+                    "type": "string",
+                    "description": "Tag for the container image; empty means the chart's appVersion"
+                }
+            }
+        },
+        "nodeSelector": {
+            "type": "object",
+            "description": "Node selector for the gadget DaemonSet",
+            "additionalProperties": false,
+            "properties": {
+                "kubernetes.io/os": {
                     "type": "string"
                 }
             }
@@ -60,17 +177,16 @@
         "provider": {
             "type": "string"
         },
-        "registry": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "domain": {
-                    "type": "string"
-                }
-            }
+        "skipLabels": {
+            "type": "boolean",
+            "description": "Skip the Helm labels (upstream default is true; Giant Swarm charts carry the team label)"
         },
         "subscriptionID": {
             "type": "string"
+        },
+        "tolerations": {
+            "type": "array",
+            "description": "Extra tolerations for the gadget DaemonSet"
         }
     }
 }

--- a/helm/inspektor-gadget/values.yaml
+++ b/helm/inspektor-gadget/values.yaml
@@ -1,6 +1,88 @@
-# This file is a Helm values file for the inspektor-gadget chart.
+# Values for the inspektor-gadget chart.
+#
+# The templates under templates/ are vendored from the upstream `gadget` chart
+# (see vendir.yml), so the keys here mirror upstream's values.yaml at the
+# vendored snapshot; only the Giant Swarm specifics differ.
+
+config:
+  # -- How to get containers start/stop notifications (auto, crio, podinformer, nri, fanotify+ebpf)
+  hookMode: auto
+
+  # -- Whether to use the fallback pod informer
+  fallbackPodInformer: true
+
+  # -- Containerd CRI Unix socket path
+  containerdSocketPath: "/run/containerd/containerd.sock"
+  # -- CRI-O CRI Unix socket path
+  crioSocketPath: "/run/crio/crio.sock"
+  # -- Docker Engine API Unix socket path
+  dockerSocketPath: "/run/docker.sock"
+  # -- Podman API Unix socket path
+  podmanSocketPath: "/run/podman/podman.sock"
+
+  # -- Enable experimental features
+  experimental: false
+
+  # -- Events buffer length. A low value could impact horizontal scaling.
+  eventsBufferLength: "16384"
+
+  # -- Daemon log level. Valid values are: "trace", "debug", "info", "warning", "error", "fatal", "panic"
+  daemonLogLevel: "info"
+
+  # -- Verify image-based gadgets
+  verifyGadgets: true
+
+  # -- Public keys used to verify image-based gadgets
+  gadgetsPublicKeys:
+    - |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoDOC0gYSxZTopenGmX3ZFvQ1DSfh
+      Ir4EKRt5jC+mXaJ7c7J+oREskYMn/SfZdRHNSOjLTZUMDm60zpXGhkFecg==
+      -----END PUBLIC KEY-----
+
+  # -- List of allowed gadgets
+  allowedGadgets: []
+
+  # -- Disallow pulling gadgets
+  disallowGadgetsPulling: false
+
+  # -- Mount pull secret (gadget-pull-secret) to pull image-based gadgets from a private registry
+  mountPullSecret: false
+
+  # -- AppArmor profile for the gadget container
+  appArmorProfile: "unconfined"
+
+  # -- Enable the OpenTelemetry metrics listener
+  otelMetricsListen: false
+
+  # -- Address to listen on for OpenTelemetry metrics
+  otelMetricsAddress: "0.0.0.0:2224"
+
 image:
-  name: "giantswarm/inspektor-gadget"
+  # -- Container image repository. Upstream's image; there is no gsoci mirror yet.
+  repository: ghcr.io/inspektor-gadget/inspektor-gadget
+  # -- Pull policy for the container image
+  pullPolicy: IfNotPresent
+  # -- Tag for the container image; empty means the chart's appVersion
   tag: ""
-registry:
-  domain: gsoci.azurecr.io
+
+# -- Node selector for the gadget DaemonSet
+nodeSelector:
+  kubernetes.io/os: linux
+
+# -- Affinity for the gadget DaemonSet
+affinity: {}
+
+# -- Capabilities for the gadget container; empty means the upstream default set
+capabilities: {}
+
+# -- Extra tolerations for the gadget DaemonSet
+tolerations: []
+
+# -- Skip the Helm labels (upstream default is true; Giant Swarm charts carry the team label)
+skipLabels: false
+
+# -- Labels added to all resources when `enabled` is true
+additionalLabels:
+  enabled: false
+  labels: {}


### PR DESCRIPTION
CircleCI never built this repo: the project was never followed, so GitHub had no CircleCI webhook and the generated `.circleci/config.yml` + `workflows.yml` were dead. The project is now followed and the webhook exists, so the generated `build-chart` job runs on every branch. It fails today for three reasons this PR fixes:

1. **The chart does not render.** `templates/` is vendored from upstream's `gadget` chart (`vendir.yml`, snapshot `5884c2b1`), but `values.yaml` was still the bootstrap stub (`image.name`, `registry.domain`), so `helm template` died in `_helpers.tpl` with `nil pointer evaluating interface {}.enabled` on `.Values.additionalLabels.enabled`. `values.yaml` now mirrors upstream's values at that snapshot, with the Giant Swarm specifics: `skipLabels: false` so the labels (and the team label) are emitted, `pullPolicy: IfNotPresent`, and `additionalLabels.enabled` as the switch the vendored helper reads. The image stays upstream's `ghcr.io/inspektor-gadget/inspektor-gadget`; there is no gsoci mirror.
2. **`C0001 HasTeamLabel`**: `_helpers.tpl` now emits `application.giantswarm.io/team` from the Chart.yaml annotation (same pattern as every other Giant Swarm chart).
3. **`C0002 IconExists`**: `Chart.yaml` declares the upstream brand logo, served from giantswarm/web-assets (https://github.com/giantswarm/web-assets/pull/410, `app-icons/inspektor-gadget/1/light.svg`).

With the chart rendering, kube-linter gets real manifests and flags what an eBPF node agent cannot satisfy (SYS_ADMIN/NET_RAW, root, host mounts) plus two things that are upstream's templates to change (no resources, deprecated `serviceAccount` field). `helm/inspektor-gadget/.kube-linter.yaml` excludes those with the rationale inline, the same mechanism node-exporter-app and friends use.

`values.schema.json` and `README.md` are regenerated by the repo's pre-commit hooks.

Verified locally with the orb's `app-build-suite:2.3.0-circleci` image (icon URL swapped to a live one, since s.giantswarm.io serves the new icon only after web-assets#410 is released): all validators, ct lint, kube-linter, `helm template` (7 documents) and `helm package` pass. `ci/circleci: build-chart` on this PR goes green once that web-assets release is deployed.

The `.ats/main.yaml` skip-steps stay as they are: the chart is still a scaffold with no tests (sibling chip 6 owns proposing ATS smokes for the Planeteers' chart repos).