### PR TITLE
test(ats): smoke-test the chart install on kind

### DIFF
--- a/.ats/main.yaml
+++ b/.ats/main.yaml
@@ -1,8 +1,15 @@
-# app-test-suite config for the generated `execute-chart-tests` CI job.
+# app-test-suite (ats >= 1.0) config for the generated execute-chart-tests CircleCI job.
+# ats creates a kind cluster, applies its bundled CRDs, installs the packaged chart with
+# `helm upgrade --install --wait` and runs `uv run pytest -m smoke` in tests/ats.
 #
-# All test steps are skipped: app-test-suite's smoke scenario runs pytest tests
-# from `tests/ats`, which this repo does not have yet (the directory only holds
-# the generated dependency files). Skipping keeps the job green while build-chart
-# still validates that the chart packages cleanly. Add `tests/ats/test_*.py`
-# smoke scenarios and drop `smoke` from skip-steps to enable real deploy testing.
-skip-steps: [smoke, functional, upgrade]
+# The smoke waits for the gadget DaemonSet on the kind node. The gadget needs
+# CAP_SYS_ADMIN/BPF/PERFMON and the host mounts the chart declares; kind's privileged
+# node container provides them (verified on the job's node image). The image tag is
+# pinned in tests/ats/smoke-values.yaml because appVersion (0.0.1) is a placeholder and the
+# vendored templates match the v0.38/v0.39 image generation, see the comment there.
+app-tests-deploy-namespace: gadget
+app-tests-app-config-file: tests/ats/smoke-values.yaml
+
+# functional: no functional tests yet.
+# upgrade: needs upgrade-tests-app-catalog-url pointing at the released chart; not wired.
+skip-steps: [functional, upgrade]

--- a/tests/ats/smoke-values.yaml
+++ b/tests/ats/smoke-values.yaml
@@ -1,0 +1,10 @@
+# Values for the app-test-suite smoke (tests/ats/test_smoke.py) on the bare kind cluster
+# the generated execute-chart-tests job creates. Layered over the chart defaults, see
+# .ats/main.yaml (app-tests-app-config-file).
+
+image:
+  # appVersion (0.0.1) is a placeholder; upstream publishes v-prefixed release tags. The
+  # vendored templates are from upstream v0.38.0-171 (vendir.lock.yml) and still pass
+  # `-controller` to gadgettracermanager, which newer images (v0.55) reject, so the pin
+  # has to stay in the v0.38/v0.39 line until the templates are re-synced.
+  tag: v0.39.0

--- a/tests/ats/test_smoke.py
+++ b/tests/ats/test_smoke.py
@@ -1,0 +1,48 @@
+"""app-test-suite smoke for the inspektor-gadget chart.
+
+app-test-suite 1.x (the generated execute-chart-tests CircleCI job) creates a kind
+cluster, installs the packaged chart with `helm upgrade --install --wait` (namespace and
+values file: .ats/main.yaml) and then runs `pytest -m smoke` in this directory. The smoke
+proves that the chart installs on a bare cluster and that the gadget DaemonSet runs on
+every node.
+"""
+
+import logging
+import os
+from typing import List
+
+import pykube
+import pytest
+from pytest_helm_charts.clusters import Cluster
+from pytest_helm_charts.k8s.daemon_set import wait_for_daemon_sets_to_run
+
+logger = logging.getLogger(__name__)
+
+# app-test-suite exports the release namespace (app-tests-deploy-namespace in .ats/main.yaml).
+namespace = os.environ.get("ATS_RELEASE_NAMESPACE", "gadget")
+daemon_sets = ["gadget"]
+timeout = 180
+
+
+@pytest.mark.smoke
+def test_api_working(kube_cluster: Cluster) -> None:
+    """The test cluster is reachable."""
+    assert kube_cluster.kube_client is not None
+    assert len(pykube.Node.objects(kube_cluster.kube_client)) >= 1
+
+
+@pytest.mark.smoke
+@pytest.mark.flaky(reruns=1, reruns_delay=15)
+def test_daemon_sets_ready(kube_cluster: Cluster) -> None:
+    """The gadget DaemonSet has a ready pod on every scheduled node."""
+    ready: List[pykube.DaemonSet] = wait_for_daemon_sets_to_run(
+        kube_cluster.kube_client, daemon_sets, namespace, timeout
+    )
+    assert len(ready) == len(daemon_sets)
+    for ds in ready:
+        status = ds.obj["status"]
+        wanted = int(status.get("desiredNumberScheduled", 0))
+        got = int(status.get("numberReady", 0))
+        assert wanted >= 1, f"{namespace}/{ds.name}: no node scheduled"
+        assert got == wanted, f"{namespace}/{ds.name}: {got}/{wanted} pods ready"
+        logger.info("DaemonSet %s/%s ready on %d node(s)", namespace, ds.name, got)


### PR DESCRIPTION
### What does this PR do?

Turns the generated `execute-chart-tests` job (app-test-suite 1.0.2, kind cluster created by the job) into a real gate: it now installs the packaged chart with `helm upgrade --install --wait` and runs `tests/ats/test_smoke.py`, which waits for the `gadget` DaemonSet to have a ready pod on the node (`pytest_helm_charts.k8s.daemon_set.wait_for_daemon_sets_to_run`). Until now `.ats/main.yaml` skipped every cluster step. Builds on #38, which made the chart render.

- `tests/ats/smoke-values.yaml` pins `image.tag: v0.39.0`. Two reasons, both worth knowing about the chart as it stands: `appVersion` is `0.0.1`, which no registry serves, so the chart's default image cannot be pulled anywhere; and the vendored templates are from upstream `v0.38.0-171` (`vendir.lock.yml`, March 2025) and still start `gadgettracermanager -serve -controller`, which the current upstream image (v0.55.1) rejects with `flag provided but not defined: -controller` (tried first). Re-syncing the templates and setting a real `appVersion` would let the pin go.
- `.ats/main.yaml`: namespace `gadget`, the values file, `smoke` dropped from `skip-steps`. The gadget's CAP_SYS_ADMIN/BPF/PERFMON and host mounts work inside kind's privileged node container.

No generated file is touched; no chart change; `test:` cuts no release.

### How does it look like?

Verified locally with the same app-build-suite and app-test-suite containers against a kind v1.36.4 cluster (the job's node image): install + `2 passed`, 12 s. The CircleCI run on this PR is the proof that counts; the project only started building today, so if the executor's kernel refuses the gadget, put `smoke` back into `skip-steps` and keep the test for later.

### What is needed from the reviewers?

Whether you want the smoke on at all while the chart's `appVersion` and vendored templates are placeholders (the pin hides that), or prefer it skipped until the chart is re-synced. Either is fine from the ATS side.
